### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-ignore = E722,W503
-exclude = .git,.pytest_cache,.tox,.venv,.idea,__pycache__,build,build,dist,docs,local
-max-line-length = 79

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -22,4 +22,4 @@ jobs:
       - run: tox -e py
 
       - if: matrix.python == 3.10
-        run: TOXENV=flake8,manifest,docs,spell tox
+        run: TOXENV=ruff,manifest,docs,spell tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include README.md
 
 include .bumpversion.cfg
 include .codespellrc
-include .flake8
+include pyproject.toml
 include tox.ini
 
 recursive-include tests *.py

--- a/dbutils/pooled_pg.py
+++ b/dbutils/pooled_pg.py
@@ -112,7 +112,7 @@ Copyright, credits and license:
 Licensed under the MIT license.
 """
 
-from queue import Queue, Empty, Full
+from queue import Empty, Full, Queue
 
 from . import __version__
 from .steady_pg import SteadyPgConnection

--- a/dbutils/steady_db.py
+++ b/dbutils/steady_db.py
@@ -372,6 +372,7 @@ class SteadyDBConnection:
                     self._store(con)
                     alive = True
             return alive
+        return None
 
     def dbapi(self):
         """Return the underlying DB-API 2 module of the connection."""

--- a/docs/make.py
+++ b/docs/make.py
@@ -4,6 +4,7 @@
 
 from glob import glob
 from os.path import splitext
+
 from docutils.core import publish_file
 
 print("Creating the documentation...")
@@ -25,11 +26,11 @@ for rst_file in glob('*.rst'):
             output = publish_file(
                 writer_name='html5', source=source, destination=destination,
                 enable_exit_status=True,
-                settings_overrides=dict(
-                    stylesheet_path='doc.css',
-                    embed_stylesheet=False,
-                    toc_backlinks=False,
-                    language_code=lang,
-                    exit_status_level=2))
+                settings_overrides={
+                    "stylesheet_path": 'doc.css',
+                    "embed_stylesheet": False,
+                    "toc_backlinks": False,
+                    "language_code": lang,
+                    "exit_status_level": 2})
 
 print("Done.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ select = [
   # "T20",  # flake8-print
   # "TRY",  # tryceratops
 ]
+# When removing rules from the `ignore` list, do `ruff rule ARG002` to see the docs
 ignore = [
   "ARG002",
   "B007",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,49 +1,48 @@
 [tool.ruff]
 select = [
-  "A",    # flake8-builtins
-  "ARG",  # flake8-unused-arguments
-  "B",    # flake8-bugbear
-  "C4",   # flake8-comprehensions
-  "C90",  # McCabe cyclomatic complexity
-  "DTZ",  # flake8-datetimez
-  "E",    # pycodestyle
-  "EXE",  # flake8-executable
-  "F",    # Pyflakes
-  "G",    # flake8-logging-format
-  "I",    # isort
-  "ICN",  # flake8-import-conventions
-  "INP",  # flake8-no-pep420
-  "INT",  # flake8-gettext
-  "ISC",  # flake8-implicit-str-concat
-  "N",    # pep8-naming
-  "PGH",  # pygrep-hooks
-  "PIE",  # flake8-pie
-  "PL",   # Pylint
-  "PT",   # flake8-pytest-style
-  "PTH",  # flake8-use-pathlib
-  "PYI",  # flake8-pyi
-  "RET",  # flake8-return
-  "RSE",  # flake8-raise
-  "RUF",  # Ruff-specific rules
-  "S",    # flake8-bandit
-  "T10",  # flake8-debugger
-  "TCH",  # flake8-type-checking
-  "TID",  # flake8-tidy-imports
-  "UP",   # pyupgrade
-  "W",    # pycodestyle
-  "YTT",  # flake8-2020
+  "A",      # flake8-builtins
+  "ARG",    # flake8-unused-arguments
+  "B",      # flake8-bugbear
+  "C4",     # flake8-comprehensions
+  "C90",    # McCabe cyclomatic complexity
+  "DTZ",    # flake8-datetimez
+  "E",      # pycodestyle
+  "EXE",    # flake8-executable
+  "F",      # Pyflakes
+  "G",      # flake8-logging-format
+  "I",      # isort
+  "ICN",    # flake8-import-conventions
+  "INP",    # flake8-no-pep420
+  "INT",    # flake8-gettext
+  "ISC",    # flake8-implicit-str-concat
+  "N",      # pep8-naming
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PT",     # flake8-pytest-style
+  "PTH",    # flake8-use-pathlib
+  "PYI",    # flake8-pyi
+  "RET",    # flake8-return
+  "RSE",    # flake8-raise
+  "RUF",    # Ruff-specific rules
+  "S",      # flake8-bandit
+  "T10",    # flake8-debugger
+  "TCH",    # flake8-type-checking
+  "TID",    # flake8-tidy-imports
+  "UP",     # pyupgrade
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
   # "ANN",  # flake8-annotations
   # "BLE",  # flake8-blind-except
   # "COM",  # flake8-commas
   # "D",    # pydocstyle
-  # "DJ",  # flake8-django
+  # "DJ",   # flake8-django
   # "EM",   # flake8-errmsg
   # "ERA",  # eradicate
   # "FBT",  # flake8-boolean-trap
   # "NPY",  # NumPy-specific rules
-  # "PD",  # pandas-vet
-  # "PLR091",  # Pylint Refactor just for max-args, max-branches, etc.
-  # "Q",  # flake8-quotes
+  # "PD",   # pandas-vet
+  # "Q",    # flake8-quotes
   # "SIM",  # flake8-simplify
   # "SLF",  # flake8-self
   # "T20",  # flake8-print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,80 @@
+[tool.ruff]
+select = [
+  "A",    # flake8-builtins
+  "ARG",  # flake8-unused-arguments
+  "B",    # flake8-bugbear
+  "C4",   # flake8-comprehensions
+  "C90",  # McCabe cyclomatic complexity
+  "DTZ",  # flake8-datetimez
+  "E",    # pycodestyle
+  "EXE",  # flake8-executable
+  "F",    # Pyflakes
+  "G",    # flake8-logging-format
+  "I",    # isort
+  "ICN",  # flake8-import-conventions
+  "INP",  # flake8-no-pep420
+  "INT",  # flake8-gettext
+  "ISC",  # flake8-implicit-str-concat
+  "N",    # pep8-naming
+  "PGH",  # pygrep-hooks
+  "PIE",  # flake8-pie
+  "PL",   # Pylint
+  "PT",   # flake8-pytest-style
+  "PTH",  # flake8-use-pathlib
+  "PYI",  # flake8-pyi
+  "RET",  # flake8-return
+  "RSE",  # flake8-raise
+  "RUF",  # Ruff-specific rules
+  "S",    # flake8-bandit
+  "T10",  # flake8-debugger
+  "TCH",  # flake8-type-checking
+  "TID",  # flake8-tidy-imports
+  "UP",   # pyupgrade
+  "W",    # pycodestyle
+  "YTT",  # flake8-2020
+  # "ANN",  # flake8-annotations
+  # "BLE",  # flake8-blind-except
+  # "COM",  # flake8-commas
+  # "D",    # pydocstyle
+  # "DJ",  # flake8-django
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "FBT",  # flake8-boolean-trap
+  # "NPY",  # NumPy-specific rules
+  # "PD",  # pandas-vet
+  # "PLR091",  # Pylint Refactor just for max-args, max-branches, etc.
+  # "Q",  # flake8-quotes
+  # "SIM",  # flake8-simplify
+  # "SLF",  # flake8-self
+  # "T20",  # flake8-print
+  # "TRY",  # tryceratops
+]
+ignore = [
+  "ARG002",
+  "B007",
+  "B904",
+  "E722",
+  "N811",
+  "N818",
+  "PIE790",
+  "PLR5501",
+  "PTH122",
+  "PTH123",
+  "S110",
+]
+line-length = 79
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 31
+
+[tool.ruff.pylint]
+allow-magic-value-types = ["int", "str"]
+max-args = 12
+max-branches = 41
+max-statements = 95
+
+[tool.ruff.per-file-ignores]
+"docs/make.py" = ["INP001"]
+"tests/*" = ["B023", "I001", "N8", "PGH004", "PLR0915", "PT009", "S101"]
+"tests/mock_pg.py" = ["RET505"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python3
+
 """Setup Script for DBUtils"""
 
 import warnings
+
 try:
     from setuptools import setup
 except ImportError:

--- a/tests/mock_pg.py
+++ b/tests/mock_pg.py
@@ -59,11 +59,13 @@ class PgConnection:
             raise InternalError
         if qstr in ('begin', 'end', 'commit', 'rollback'):
             self.session.append(qstr)
+            return None
         elif qstr.startswith('select '):
             self.num_queries += 1
             return qstr[7:]
         elif qstr.startswith('set '):
             self.session.append(qstr[4:])
+            return None
         else:
             raise ProgrammingError
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8,9,10,11}, flake8, manifest, docs, spell
+envlist = py3{6,7,8,9,10,11}, ruff, manifest, docs, spell
 
 [testenv]
 setenv =
@@ -14,11 +14,11 @@ deps = codespell
 commands =
     codespell .
 
-[testenv:flake8]
+[testenv:ruff]
 basepython = python3.10
-deps = flake8
+deps = ruff
 commands =
-    flake8 .
+    ruff .
 
 [testenv:manifest]
 basepython = python3.10


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

Changes to Python files were done with `ruff --fix .`.